### PR TITLE
Example of using usethis::ui_* message functions

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,0 +1,2 @@
+^.*\.Rproj$
+^\.Rproj\.user$

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.Rproj.user
+.Rhistory
+.RData
+.Ruserdata

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,7 +19,9 @@ Imports:
     tidyr,
     httpuv,
     vctrs,
-    rlang
+    rlang,
+    purrr,
+    usethis
 Remotes: 
     tidyverse/tidyr,
     r-lib/vctrs,

--- a/R/invitations.R
+++ b/R/invitations.R
@@ -85,7 +85,15 @@ invitation_rescind <- function(invitation_id) {
 
   check_auth()
 
-  req <- rscloud_DELETE(path = c("invitations", invitation_id),
-                        task = paste0("Failed to remove invitation_id: ", invitation_id))
+  req <- rscloud_DELETE(path = c("invitations", invitation_id))
+
+  if (succeeded(req)) {
+    usethis::ui_done("Invitation {usethis::ui_value(invitation_id)} rescinded.")
+  }
+
+  if (failed(req)) {
+    usethis::ui_oops("Failed to rescind invitation {usethis::ui_value(invitation_id)}.")
+  }
+
 }
 

--- a/R/users.R
+++ b/R/users.R
@@ -98,6 +98,14 @@ space_remove_user <- function(space_id, user_id) {
 
   check_auth()
 
-  rscloud_DELETE(path = c("spaces", space_id, "members", user_id),
-                 task = paste0("Failed to remove user_id: ", user_id))
+  req <- rscloud_DELETE(path = c("spaces", space_id, "members", user_id))
+
+  if (succeeded(req)) {
+    usethis::ui_done("Removed user {usethis::ui_value(user_id)} from space {usethis::ui_value(space_id)}.")
+  }
+
+  if (failed(req)) {
+    usethis::ui_oops("Failed to remove user {usethis::ui_value(user_id)} from space {usethis::ui_value(space_id)}.")
+  }
+
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -32,14 +32,13 @@ rscloud_GET <- function(path, ..., task = NULL, caller_subject = "space", versio
   httr::content(req)
 }
 
-rscloud_DELETE <- function(path, ..., task = NULL, version = "v1") {
+rscloud_DELETE <- function(path, ..., version = "v1") {
   url <- httr::modify_url(url = .globals$API_URL, path = c(version, path))
 
-  req <- httr::DELETE(url, ... ,  httr::config(token = .globals$rscloud_token))
+  purrr::safely(httr::DELETE)(url, ... , httr::config(token = .globals$rscloud_token))
 
   #TODO: Check for a variety of fun http status codes and provide a better error message
 
-  httr::stop_for_status(req, task = task)
 }
 
 rscloud_POST <- function(path, ... , task = NULL, caller_subject = "space", version = "v1") {
@@ -66,3 +65,13 @@ parse_times <- function(df) {
     updated_time = as.POSIXct(strptime(updated_time, "%Y-%m-%dT%H:%M:%S"))
   )
 }
+
+#' Convenience functions for ui_* messages
+succeeded = function(x) {
+  !http_error(x$result)
+}
+
+failed = function(x) {
+  http_error(x$result)
+}
+

--- a/R/utils.R
+++ b/R/utils.R
@@ -66,12 +66,12 @@ parse_times <- function(df) {
   )
 }
 
-#' Convenience functions for ui_* messages
-succeeded = function(x) {
-  !http_error(x$result)
+# Convenience functions for ui_* messages
+succeeded <- function(x) {
+  !httr::http_error(x$result)
 }
 
-failed = function(x) {
-  http_error(x$result)
+failed <- function(x) {
+  httr::http_error(x$result)
 }
 


### PR DESCRIPTION
- Add two convenience functions `succeeded()` and `failed()` that make use of `httr::http_error()` to `utils.R`
- Modify `rscloud_DELETE()` to wrap the API call in `purrr::safely` so that it returns a list with result and error
- Modify the two functions that use `rscloud_DELETE()`, `space_remove_user()` and `invitation_rescind()` to use `usethis::ui_done()` and `usethis::ui_oops()` messages for success / failure
- Modify the DESCRIPTION to import purrr and usethis.

Note: I have not changed the name of `space_remove_user()` but one might consider renaming it to `user_remove()` to match other functions in `users.R`.

