### PR TITLE
Fix how `last_activity` is reported

### DIFF
--- a/R/ptype.R
+++ b/R/ptype.R
@@ -1,30 +1,12 @@
 NA_datetime_ <- vctrs::new_datetime(NA_real_, tzone = "UTC")
 
-rscloud_ptypes_30 <- list(
+rscloud_ptypes <- list(
   usages = tibble::tibble(
     "user_id" = NA_integer_,
     "display_name" = NA_character_,
     "first_name" = NA_character_,
     "last_name" = NA_character_,
     "last_activity" = NA_datetime_,
-    "compute" = NA_integer_,
-    "active_accounts" = NA_integer_,
-    "active_spaces" = NA_integer_,
-    "active_users" = NA_integer_,
-    "active_projects" = NA_integer_,
-    "deleted" = NA,
-    "deleted_time" = NA,
-    "from" = NA_datetime_,
-    "until" = NA_datetime_,
-  )
-)
-
-rscloud_ptypes_90 <- list(
-  usages = tibble::tibble(
-    "user_id" = NA_integer_,
-    "display_name" = NA_character_,
-    "first_name" = NA_character_,
-    "last_name" = NA_character_,
     "compute" = NA_real_,
     "active_accounts" = NA_integer_,
     "active_spaces" = NA_integer_,

--- a/R/ptype.R
+++ b/R/ptype.R
@@ -1,17 +1,35 @@
 NA_datetime_ <- vctrs::new_datetime(NA_real_, tzone = "UTC")
 
-rscloud_ptypes <- list(
+rscloud_ptypes_30 <- list(
   usages = tibble::tibble(
     "user_id" = NA_integer_,
     "display_name" = NA_character_,
     "first_name" = NA_character_,
     "last_name" = NA_character_,
     "last_activity" = NA_datetime_,
+    "compute" = NA_integer_,
+    "active_accounts" = NA_integer_,
+    "active_spaces" = NA_integer_,
+    "active_users" = NA_integer_,
+    "active_projects" = NA_integer_,
+    "deleted" = NA,
+    "deleted_time" = NA,
+    "from" = NA_datetime_,
+    "until" = NA_datetime_,
+  )
+)
+
+rscloud_ptypes_90 <- list(
+  usages = tibble::tibble(
+    "user_id" = NA_integer_,
+    "display_name" = NA_character_,
+    "first_name" = NA_character_,
+    "last_name" = NA_character_,
     "compute" = NA_real_,
-    "active_projects" = NA_real_,
-    "active_spaces" = NA_real_,
-    "active_accounts" = NA_real_,
-    "active_users" = NA_real_,
+    "active_accounts" = NA_integer_,
+    "active_spaces" = NA_integer_,
+    "active_users" = NA_integer_,
+    "active_projects" = NA_integer_,
     "deleted" = NA,
     "deleted_time" = NA,
     "from" = NA_datetime_,

--- a/man/space_member_usage.Rd
+++ b/man/space_member_usage.Rd
@@ -14,11 +14,15 @@ space_member_usage(space, filters = NULL)
 \description{
 Returns the list of members and their usage information for a given space.
 You must either be the admin of the space or your role must have permissions
-to see the members list.
+to see the members list. Result will include \code{last_activity} only if only
+if the time window is less than or equal to 31 days.
 }
 \examples{
 \dontrun{
-# Usage in the last 90 days for each user
+# Usage in the last 30 days for each user, will report last_activity
+space_member_usage(space, filters = list(groupby = "user_id", from = "30d"))
+
+# Usage in the last 90 days for each user, will not report last_activity
 space_member_usage(space, filters = list(groupby = "user_id", from = "90d"))
 }
 

--- a/man/space_member_usage.Rd
+++ b/man/space_member_usage.Rd
@@ -14,8 +14,10 @@ space_member_usage(space, filters = NULL)
 \description{
 Returns the list of members and their usage information for a given space.
 You must either be the admin of the space or your role must have permissions
-to see the members list. Result will include \code{last_activity} only if only
-if the time window is less than or equal to 31 days.
+to see the members list. Result will include true \code{last_activity} (date user
+was last active) only if only if the time window is less than or equal to 31
+days. For longer time periods \code{last_activity} for all users will be reported
+as \code{NA} regardless of the true date of their last activity.
 }
 \examples{
 \dontrun{

--- a/tests/testthat/test-members.R
+++ b/tests/testthat/test-members.R
@@ -52,7 +52,7 @@ test_that("batch member adding/invitation rescinding", {
 })
 
 # test space_member_usage
-test_that("member usage for 90 days, returns tibble with 13 columns", {
+test_that("member usage for 90 days, returns tibble with 14 columns", {
 
   space <- rscloud_space(name = "test-space-1")
 
@@ -65,12 +65,12 @@ test_that("member usage for 90 days, returns tibble with 13 columns", {
 
   expect_identical(
     ncol(usages),
-    13L
+    14L
   )
 
   expect_equal(
     purrr::map_chr(vctrs::vec_ptype(usages), typeof),
-    purrr::map_chr(vctrs::vec_ptype(rscloud_ptypes_90$usages), typeof)
+    purrr::map_chr(vctrs::vec_ptype(rscloud_ptypes$usages), typeof)
   )
 
 })
@@ -93,7 +93,7 @@ test_that("member usage for 30 days, returns tibble with 14 columns", {
 
   expect_equal(
     purrr::map_chr(vctrs::vec_ptype(usages), typeof),
-    purrr::map_chr(vctrs::vec_ptype(rscloud_ptypes_30$usages), typeof)
+    purrr::map_chr(vctrs::vec_ptype(rscloud_ptypes$usages), typeof)
   )
 
 })

--- a/tests/testthat/test-members.R
+++ b/tests/testthat/test-members.R
@@ -52,11 +52,34 @@ test_that("batch member adding/invitation rescinding", {
 })
 
 # test space_member_usage
-test_that("member usage, returns tibble with 14 columns", {
+test_that("member usage for 90 days, returns tibble with 13 columns", {
 
   space <- rscloud_space(name = "test-space-1")
 
   usages <- space_member_usage(space, filters = list(groupby = "user_id", from = "90d"))
+
+  expect_identical(
+    class(usages),
+    c("tbl_df", "tbl", "data.frame")
+  )
+
+  expect_identical(
+    ncol(usages),
+    13L
+  )
+
+  expect_equal(
+    purrr::map_chr(vctrs::vec_ptype(usages), typeof),
+    purrr::map_chr(vctrs::vec_ptype(rscloud_ptypes_90$usages), typeof)
+  )
+
+})
+
+test_that("member usage for 30 days, returns tibble with 14 columns", {
+
+  space <- rscloud_space(name = "test-space-1")
+
+  usages <- space_member_usage(space, filters = list(groupby = "user_id", from = "30d"))
 
   expect_identical(
     class(usages),
@@ -70,7 +93,7 @@ test_that("member usage, returns tibble with 14 columns", {
 
   expect_equal(
     purrr::map_chr(vctrs::vec_ptype(usages), typeof),
-    purrr::map_chr(vctrs::vec_ptype(rscloud_ptypes$usages), typeof)
+    purrr::map_chr(vctrs::vec_ptype(rscloud_ptypes_30$usages), typeof)
   )
 
 })


### PR DESCRIPTION
Due to a recent API update, `last_activity` is only given if the time window is less than or equal to 31 days. This PR updates the` space_member_usage()` function to reflect this update as well as the associated test files.

Addresses #49.