### PR TITLE
Transition generic endpoint to more specific one.

### DIFF
--- a/R/projects.R
+++ b/R/projects.R
@@ -15,12 +15,12 @@ space_project_list <- function(space, filters = NULL) {
     purrr::flatten()
 
   response <- rscloud_rest(space_project_list_url,
-                           query = query_list
+    query = query_list
   )
 
   verify_response_length(response, "projects", filters)
 
-  projects <- collect_paginated(response, path = space_project_list_url, query = query_list)
+  projects <- collect_paginated(response, path = space_project_list_url, collection = 'projects', query = query_list)
 
   projects %>%
     tidy_list() %>%

--- a/R/projects.R
+++ b/R/projects.R
@@ -13,7 +13,8 @@ space_project_list <- function(space, filters = NULL) {
     append(list("filter" = paste0("space_id:", space_id))) %>%
     purrr::flatten()
 
-  response <- rscloud_rest("projects",
+  space_project_list_url = paste0("/spaces", space_id, "/content/projects")
+  response <- rscloud_rest(space_project_list_url,
     query = query_list
   )
 

--- a/R/projects.R
+++ b/R/projects.R
@@ -8,19 +8,13 @@
 #' @export
 space_project_list <- function(space, filters = NULL) {
   space_id <- space_id(space)
-  query_list <- filters %>%
-    purrr::map(~ list("filter" = .x)) %>%
-    append(list("filter" = paste0("space_id:", space_id))) %>%
-    purrr::flatten()
+  space_project_list_url <- paste0("/spaces", space_id, "/content/projects")
 
-  space_project_list_url = paste0("/spaces", space_id, "/content/projects")
-  response <- rscloud_rest(space_project_list_url,
-    query = query_list
-  )
+  response <- rscloud_rest(space_project_list_url)
 
   verify_response_length(response, "projects", filters)
 
-  projects <- collect_paginated(response, path = "projects", query = query_list)
+  projects <- collect_paginated(response, path = space_project_list_url)
 
   projects %>%
     tidy_list() %>%

--- a/R/projects.R
+++ b/R/projects.R
@@ -8,13 +8,19 @@
 #' @export
 space_project_list <- function(space, filters = NULL) {
   space_id <- space_id(space)
-  space_project_list_url <- paste0("/spaces", space_id, "/content/projects")
+  space_project_list_url <- paste0("/spaces/", space_id, "/content/projects")
 
-  response <- rscloud_rest(space_project_list_url)
+  query_list <- filters %>%
+    purrr::map(~ list("filter" = .x)) %>%
+    purrr::flatten()
+
+  response <- rscloud_rest(space_project_list_url,
+                           query = query_list
+  )
 
   verify_response_length(response, "projects", filters)
 
-  projects <- collect_paginated(response, path = space_project_list_url)
+  projects <- collect_paginated(response, path = space_project_list_url, query = query_list)
 
   projects %>%
     tidy_list() %>%

--- a/R/spaces-utils.R
+++ b/R/spaces-utils.R
@@ -11,7 +11,7 @@ RSCloudSpace <- R6::R6Class("RSCloudSpace",
         glue::glue(
           "RStudio Cloud Space (ID: {private$id})
         <{info$name}>
-          users: {info$user_count} | projects: {info$project_count}
+          users: {info$user_count} | projects: {info$content_count}
         "
         )
       } else {


### PR DESCRIPTION
This transitions the space projects call to a new set of endpoints that are more optimized for handling requests for projects in a space.

This also tweaks a spot in the space serialization where the name of the count has changed.