### PR TITLE
Add content action.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -46,4 +46,4 @@ Config/testthat/edition: 3
 Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.1.2
+RoxygenNote: 7.2.1

--- a/R/members.R
+++ b/R/members.R
@@ -158,9 +158,9 @@ space_member_add.data.frame <- function(space, users, ...) {
 #' @param users ID number or email of the user to be removed, or a data frame
 #'   with either a `user_id` or `email` column.
 #' @param content_action What to do with the users content after they are
-#'   removed from the space. Options for the content are to: `leave_in_space`
-#'   leaving the content where it is, `archive_in_space` moving the content to
-#'   the space archive, and `trash_in_space` moving the content to the spaces
+#'   removed from the space. Options for the content are to: "leave"
+#'   leaving the content where it is, "archive" moving the content to
+#'   the space archive, and "trash" moving the content to the spaces
 #'   trash.
 #' @param ask Whether to ask user for confirmation of deletion.
 #'
@@ -177,7 +177,7 @@ space_member_remove.numeric <- function(space, users, content_action = NULL, ask
   }
 
   if (rlang::is_null(content_action)) {
-    usethis::ui_stop("{ui_field('content_action')} must be either `leave_in_space`, `archive_in_space`, `trash_in_space`.")
+    usethis::ui_stop("{ui_field('content_action')} must be either \"leave\", \"archive\", \"trash\".")
   }
 
   if (ask) {
@@ -191,7 +191,7 @@ space_member_remove.numeric <- function(space, users, content_action = NULL, ask
 
   space_id <- space_id(space)
 
-  content_action <- tolower(as.character(content_action))
+  content_action <- as.character(content_action)
 
   req <- rscloud_rest(
     path = c("spaces", space_id, "members", users),
@@ -226,7 +226,7 @@ space_member_remove.character <- function(space, users, content_action = NULL, a
 #' @export
 space_member_remove.data.frame <- function(space, users, content_action = NULL, ask = TRUE) {
   if (rlang::is_null(content_action)) {
-    usethis::ui_stop("{ui_field('content_action')} must be either `leave_in_space`, `archive_in_space`, `trash_in_space`.")
+    usethis::ui_stop("{ui_field('content_action')} must be either \"leave\", \"archive\", \"trash\".")
   }
 
   users <- if (!is.null(user_id <- users[["user_id"]])) {

--- a/R/members.R
+++ b/R/members.R
@@ -177,7 +177,7 @@ space_member_remove.numeric <- function(space, users, content_action = NULL, ask
   }
 
   if (rlang::is_null(content_action)) {
-    usethis::ui_stop("{ui_field('content_action')} must be either \"leave\", \"archive\", \"trash\".")
+    usethis::ui_stop("{ui_field('content_action')} must be either \"keep\", \"archive\", \"trash\".")
   }
 
   if (ask) {
@@ -192,6 +192,10 @@ space_member_remove.numeric <- function(space, users, content_action = NULL, ask
   space_id <- space_id(space)
 
   content_action <- as.character(content_action)
+
+  if (identical(content_action, 'keep')) {
+    content_action = 'leave'
+  }
 
   req <- rscloud_rest(
     path = c("spaces", space_id, "members", users),
@@ -226,7 +230,7 @@ space_member_remove.character <- function(space, users, content_action = NULL, a
 #' @export
 space_member_remove.data.frame <- function(space, users, content_action = NULL, ask = TRUE) {
   if (rlang::is_null(content_action)) {
-    usethis::ui_stop("{ui_field('content_action')} must be either \"leave\", \"archive\", \"trash\".")
+    usethis::ui_stop("{ui_field('content_action')} must be either \"keep\", \"archive\", \"trash\".")
   }
 
   users <- if (!is.null(user_id <- users[["user_id"]])) {

--- a/README.Rmd
+++ b/README.Rmd
@@ -52,7 +52,7 @@ members <- space %>%
   space_member_list() %>% 
   dplyr::filter(email != "rscloud.test.01@gmail.com")
 space %>% 
-  purrr::safely(space_member_remove)(members, remove_projects = TRUE, ask = FALSE)
+  purrr::safely(space_member_remove)(members, content_action = 'leave_in_space', ask = FALSE)
 
 space %>% 
   purrr::possibly(space_invitation_list, otherwise = NULL)() %>% 

--- a/README.Rmd
+++ b/README.Rmd
@@ -52,7 +52,7 @@ members <- space %>%
   space_member_list() %>% 
   dplyr::filter(email != "rscloud.test.01@gmail.com")
 space %>% 
-  purrr::safely(space_member_remove)(members, content_action = 'leave_in_space', ask = FALSE)
+  purrr::safely(space_member_remove)(members, content_action = "leave", ask = FALSE)
 
 space %>% 
   purrr::possibly(space_invitation_list, otherwise = NULL)() %>% 

--- a/man/space_member_remove.Rd
+++ b/man/space_member_remove.Rd
@@ -7,13 +7,13 @@
 \alias{space_member_remove.data.frame}
 \title{Remove Members}
 \usage{
-space_member_remove(space, users, remove_projects = NULL, ask = TRUE)
+space_member_remove(space, users, content_action = NULL, ask = TRUE)
 
-\method{space_member_remove}{numeric}(space, users, remove_projects = NULL, ask = TRUE)
+\method{space_member_remove}{numeric}(space, users, content_action = NULL, ask = TRUE)
 
-\method{space_member_remove}{character}(space, users, remove_projects = NULL, ask = TRUE)
+\method{space_member_remove}{character}(space, users, content_action = NULL, ask = TRUE)
 
-\method{space_member_remove}{data.frame}(space, users, remove_projects = NULL, ask = TRUE)
+\method{space_member_remove}{data.frame}(space, users, content_action = NULL, ask = TRUE)
 }
 \arguments{
 \item{space}{A space object created using \code{rscloud_space()}.}
@@ -21,9 +21,11 @@ space_member_remove(space, users, remove_projects = NULL, ask = TRUE)
 \item{users}{ID number or email of the user to be removed, or a data frame
 with either a \code{user_id} or \code{email} column.}
 
-\item{remove_projects}{Whether to remove user's projects from the workspace
-and move them to their personal space or to keep the projects in the
-workspace.}
+\item{content_action}{What to do with the users content after they are
+removed from the space. Options for the content are to: \code{leave_in_space}
+leaving the content where it is, \code{archive_in_space} moving the content to
+the space archive, and \code{trash_in_space} moving the content to the spaces
+trash.}
 
 \item{ask}{Whether to ask user for confirmation of deletion.}
 }

--- a/man/space_member_remove.Rd
+++ b/man/space_member_remove.Rd
@@ -22,9 +22,9 @@ space_member_remove(space, users, content_action = NULL, ask = TRUE)
 with either a \code{user_id} or \code{email} column.}
 
 \item{content_action}{What to do with the users content after they are
-removed from the space. Options for the content are to: \code{leave_in_space}
-leaving the content where it is, \code{archive_in_space} moving the content to
-the space archive, and \code{trash_in_space} moving the content to the spaces
+removed from the space. Options for the content are to: "leave"
+leaving the content where it is, "archive" moving the content to
+the space archive, and "trash" moving the content to the spaces
 trash.}
 
 \item{ask}{Whether to ask user for confirmation of deletion.}

--- a/tests/testthat/helper-initialize.R
+++ b/tests/testthat/helper-initialize.R
@@ -7,7 +7,7 @@ clean_up <- function() {
     space_member_list() %>%
     dplyr::filter(email != "rscloud.test.01@gmail.com")
   space %>%
-    purrr::safely(space_member_remove)(members, remove_projects = TRUE, ask = FALSE)
+    purrr::safely(space_member_remove)(members, content_action = 'leave_in_space', ask = FALSE)
 
   space %>%
     purrr::possibly(space_invitation_list, otherwise = NULL)() %>%

--- a/tests/testthat/helper-initialize.R
+++ b/tests/testthat/helper-initialize.R
@@ -7,7 +7,7 @@ clean_up <- function() {
     space_member_list() %>%
     dplyr::filter(email != "rscloud.test.01@gmail.com")
   space %>%
-    purrr::safely(space_member_remove)(members, content_action = 'leave_in_space', ask = FALSE)
+    purrr::safely(space_member_remove)(members, content_action = "leave", ask = FALSE)
 
   space %>%
     purrr::possibly(space_invitation_list, otherwise = NULL)() %>%


### PR DESCRIPTION
This adjusts the remove space user function to support `content_action` instead of `remove_projects`. The workflow here is going to change shortly and when you remove users from a space you will only be able to: leave their content in the space, archive their content (using the relatively new space content archive), or move the space to the trash.

Closes https://github.com/rstudio/rscloud/issues/53